### PR TITLE
sst5 support instead of sst2

### DIFF
--- a/src/pipelines/sentiment.rs
+++ b/src/pipelines/sentiment.rs
@@ -142,9 +142,9 @@ impl SentimentModel {
         let labels = self.sequence_classification_model.predict(input);
         let mut sentiments = Vec::with_capacity(labels.len());
         for label in labels {
-            let polarity = if label.id == 5 || label.id == 4 {
+            let polarity = if label.id == 4 || label.id == 3 {
                 SentimentPolarity::Positive
-            } else if label.id == 3 {
+            } else if label.id == 2 {
                 SentimentPolarity::Neutral
             } else {
                 SentimentPolarity::Negative

--- a/src/pipelines/sentiment.rs
+++ b/src/pipelines/sentiment.rs
@@ -65,6 +65,7 @@ use serde::{Deserialize, Serialize};
 pub enum SentimentPolarity {
     Positive,
     Negative,
+    Neutral,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -141,8 +142,10 @@ impl SentimentModel {
         let labels = self.sequence_classification_model.predict(input);
         let mut sentiments = Vec::with_capacity(labels.len());
         for label in labels {
-            let polarity = if label.id == 1 {
+            let polarity = if label.id == 5 || label.id == 4 {
                 SentimentPolarity::Positive
+            } else if label.id == 3 {
+                SentimentPolarity::Neutral
             } else {
                 SentimentPolarity::Negative
             };


### PR DESCRIPTION
For sentiment, sst5 predicts 5 sentiment categories - "very positive", "positive", "neutral", "negative", and "very negative".

sst2 predicts 2 sentiment categories - "positive" and "negative".

rust-bert only supports sst2, not sst5, but we want to use sst5

This is a somewhat ugly, though not that bad imo hot-fix - the proper solution might be to work on getting rust-bert to support both, or rather to support reading a config file with a label -> sentiment mapping (although that would remove the ability to have the sentiment values be in an enum) - I don't see how to do that without making a breaking API change?

This also is added on top of a particular commit - I was not able to easily update our rust-bert to 0.19.